### PR TITLE
Adding NETWAR info to showcase

### DIFF
--- a/_data/showcase.yml
+++ b/_data/showcase.yml
@@ -24,3 +24,5 @@
   url: https://www.multimadness.de
 - name: Nordish Gaming Convention
   url: https://ngc-germany.de
+- name: NETWAR
+  url: https://www.netwar.org


### PR DESCRIPTION
I am an admin for the NETWAR LAN held in Omaha, NE (USA) and would like to add our event to the showcase page.
https://www.netwar.org
https://github.com/netwarlan
