### PR TITLE
Update index.md

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -25,7 +25,7 @@ If you have a Linux machine that already has Docker pre-installed, please just r
 <p class="line">
 <span class="path">~</span>
 <span class="prompt">$</span>
-<span class="command">git clone https://github.com/lancachenet/docker-compose/ lancache</span>
+<span class="command">git clone https://github.com/lancachenet/docker-compose/ lancache  --depth=1</span>
 </p>
 <p class="line">
 <span class="path">~</span>


### PR DESCRIPTION
Using --depth=1 downloads only the latest version of the folder instead of the whole git history.
As user most people are not interested of the whole history (mostly because they won't need to edit git files), this way it is faster to download it.