### PR TITLE
Replace docker-compose with docker compose

### DIFF
--- a/_docs/containers/dns/variables.md
+++ b/_docs/containers/dns/variables.md
@@ -15,7 +15,7 @@ Changing environment variables in docker requires you to delete and recreate you
    </p>
 </div>
 
-If you are using docker compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
+If you are using `docker compose` these variables can be changed by editing the `.env` file provided. If a specific variable does not exist in your version of the `.env` just add a new line.
 
 If you are using docker from the command line environment variables are specified using `-e VARIABLE=VALUE` format when you launch the container.
 

--- a/_docs/containers/dns/variables.md
+++ b/_docs/containers/dns/variables.md
@@ -15,7 +15,7 @@ Changing environment variables in docker requires you to delete and recreate you
    </p>
 </div>
 
-If you are using docker-compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
+If you are using docker compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
 
 If you are using docker from the command line environment variables are specified using `-e VARIABLE=VALUE` format when you launch the container.
 

--- a/_docs/containers/monolithic/variables.md
+++ b/_docs/containers/monolithic/variables.md
@@ -15,7 +15,7 @@ Changing environment variables in docker requires you to delete and recreate you
    </p>
 </div>
 
-If you are using docker compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
+If you are using `docker compose` these variables can be changed by editing the `.env` file provided. If a specific variable does not exist in your version of the `.env` just add a new line.
 
 If you are using docker from the command line environment variables are specified using `-e VARIABLE=VALUE` format when you launch the container.
 

--- a/_docs/containers/monolithic/variables.md
+++ b/_docs/containers/monolithic/variables.md
@@ -15,7 +15,7 @@ Changing environment variables in docker requires you to delete and recreate you
    </p>
 </div>
 
-If you are using docker-compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
+If you are using docker compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
 
 If you are using docker from the command line environment variables are specified using `-e VARIABLE=VALUE` format when you launch the container.
 

--- a/_docs/containers/sniproxy/variables.md
+++ b/_docs/containers/sniproxy/variables.md
@@ -15,7 +15,7 @@ Changing environment variables in docker requires you to delete and recreate you
    </p>
 </div>
 
-If you are using docker compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
+If you are using `docker compose` these variables can be changed by editing the `.env` file provided. If a specific variable does not exist in your version of the `.env` just add a new line.
 
 If you are using docker from the command line environment variables are specified using `-e VARIABLE=VALUE` format when you launch the container.
 

--- a/_docs/containers/sniproxy/variables.md
+++ b/_docs/containers/sniproxy/variables.md
@@ -15,7 +15,7 @@ Changing environment variables in docker requires you to delete and recreate you
    </p>
 </div>
 
-If you are using docker-compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
+If you are using docker compose these variables can be changed by editing the .env file provided. If a specific variable does not exist in your version of the .env just add a new line.
 
 If you are using docker from the command line environment variables are specified using `-e VARIABLE=VALUE` format when you launch the container.
 

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -13,7 +13,12 @@ The best and quickest way is to get started with lancache.net is to use the quic
 
 * A modern Linux distribution supporting Docker, eg [Ubuntu](https://www.ubuntu.com) or [CentOS](https://www.centos.org/)
 * [Docker](https://www.docker.com/)
-* [docker-compose](https://docs.docker.com/compose/install/)
+
+<div class="note">
+    <p>
+    	Installing Docker via your package manager may install an unsupported out of date version.  It is recommended to install it via Docker's official install instructions, which can be found <a href="https://docs.docker.com/engine/install/">here</a>
+    </p>
+</div>
 
 ## The Simplest Method
 
@@ -40,7 +45,7 @@ If you have a Linux machine that already has Docker pre-installed, please just r
 <p class="line">
 <span class="path">~/lancache</span>
 <span class="prompt">$</span>
-<span class="command">docker-compose up -d</span>
+<span class="command">docker compose up -d</span>
 </p>
 <p class="line">
 <span class="output"># => Configure your router to serve ONLY lancache-dns</span>
@@ -61,15 +66,15 @@ This should bring up a fully functional LanCache and DNS container, and an SNI P
 ## More Detail
 
 When you edit the .env file most users are going to need to make the following changes:
-* LANCACHE_IP should be set to the ip address that you wish your DNS to hand out for your cache container. In normal operation this would be the ip of the box running your cache.
-* DNS_BIND_IP can be commented out in a simple setup or you can choose the ip address of your dns container (which could be the same as your lancache ip)
-* CACHE_ROOT is where you want to store the cached data. For best practice we recommend a mount point on a separate volume from your OS.
-* CACHE_DISK_SIZE ensure this matches the size of the volume you have the cache root on. Remember to leave some space available. The size should be in either megabytes (suffix `m`) or gigabytes (suffix `g`). (For very large sizes you should understand what CACHE_INDEX_SIZE does)
+* `LANCACHE_IP` should be set to the ip address that you wish your DNS to hand out for your cache container. In normal operation this would be the ip of the box running your cache.
+* `DNS_BIND_IP` can be commented out in a simple setup or you can choose the ip address of your dns container (which could be the same as your lancache ip)
+* `CACHE_ROOT` is where you want to store the cached data. For best practice we recommend a mount point on a separate volume from your OS.
+* `CACHE_DISK_SIZE` ensure this matches the size of the volume you have the cache root on. The cache will try to keep around 100g free space, but you may want to pick an appropriate size that leaves some space available for other data. The size should be in gigabytes (suffix `g`) or terabytes (suffix `t`). (For very large sizes you should understand what `CACHE_INDEX_SIZE` does)
 
 <div class="note info">
 	<h5>Common Issues</h5>
     <p>
-    	Be sure to check the <a href="/docs/common-issues/">common issues</a> page if you have any problems setting up your server.    
+    	Be sure to check the <a href="/docs/common-issues/">common issues</a> page if you have any problems setting up your server.
     </p>
 </div>
 
@@ -78,4 +83,3 @@ If you want to play with advanced installation and further configuration options
 
 * [docker-compose](/docs/installation/docker-compose/)
 * [Manual docker](/docs/installation/docker/)
-{% comment %}* [Step by step](/docs/step-by-step/01-setup/) {% endcomment %}

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -65,11 +65,11 @@ This should bring up a fully functional LanCache and DNS container, and an SNI P
 
 ## More Detail
 
-When you edit the .env file most users are going to need to make the following changes:
+When you edit the `.env` file most users are going to need to make the following changes:
 * `LANCACHE_IP` should be set to the ip address that you wish your DNS to hand out for your cache container. In normal operation this would be the ip of the box running your cache.
 * `DNS_BIND_IP` can be commented out in a simple setup or you can choose the ip address of your dns container (which could be the same as your lancache ip)
 * `CACHE_ROOT` is where you want to store the cached data. For best practice we recommend a mount point on a separate volume from your OS.
-* `CACHE_DISK_SIZE` ensure this matches the size of the volume you have the cache root on. The cache will try to keep around 100g free space, but you may want to pick an appropriate size that leaves some space available for other data. The size should be in gigabytes (suffix `g`) or terabytes (suffix `t`). (For very large sizes you should understand what `CACHE_INDEX_SIZE` does)
+* `CACHE_DISK_SIZE` ensure this matches the size of the volume you have the cache root on. The cache will try to keep around `10g` free space (see `MIN_DISK_FREE`), but you may want to pick an appropriate size that leaves some space available for other data. The size should be in gigabytes (suffix `g`) or terabytes (suffix `t`). (For very large sizes you should understand what `CACHE_INDEX_SIZE` does)
 
 <div class="note info">
 	<h5>Common Issues</h5>

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -23,5 +23,5 @@ The best and quickest way is to get started with lancache.net is to use the [qui
 
 For detailed install instructions have a look at the guide for your operating system.
 
-* [docker-compose](/docs/installation/docker-compose/)
+* [Docker Compose](/docs/installation/docker-compose/)
 * [Manual docker](/docs/installation/docker/)

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -11,7 +11,6 @@ The best and quickest way is to get started with lancache.net is to use the [qui
 
 * A modern Linux distribution supporting Docker, eg [Ubuntu](https://www.ubuntu.com) or [CentOS](https://www.centos.org/)
 * [Docker](https://www.docker.com/)
-* [docker-compose](https://docs.docker.com/compose/install/)
 
     <div class="note info">
     <h5>Common Issues</h5>
@@ -26,4 +25,3 @@ For detailed install instructions have a look at the guide for your operating sy
 
 * [docker-compose](/docs/installation/docker-compose/)
 * [Manual docker](/docs/installation/docker/)
-{% comment %}* [Step by step](/docs/step-by-step/01-setup/) {% endcomment %}

--- a/_docs/installation/docker-compose.md
+++ b/_docs/installation/docker-compose.md
@@ -11,18 +11,23 @@ The best and quickest way is to get started with lancache.net is to use the [qui
 
 * A modern Linux distribution supporting Docker, eg [Ubuntu](https://www.ubuntu.com) or [CentOS](https://www.centos.org/)
 * [Docker](https://www.docker.com/)
-* [docker-compose](https://docs.docker.com/compose/install/)
+
+<div class="note">
+    <p>
+    	Installing Docker via your package manager may install an unsupported out of date version.  It is recommended to install it via Docker's official install instructions, which can be found <a href="https://docs.docker.com/engine/install/">here</a>
+    </p>
+</div>
 
 ## Checkout Docker-compose
 
-Our docker-compose repo provides everything you need to get up and running with a basic setup. Start by pulling the docker-compose as follows
+Our docker-compose repo provides everything you need to get up and running with a basic setup. Start by pulling the docker-compose repo as follows
 ```sh
 git clone https://github.com/lancachenet/docker-compose.git
 ```
 
 ## Environment Setup
 
-Before starting the containers it's important to configure the basics by editing the `.env` file. Work through the file and read the comments before updating each setting. 
+Before starting the containers it's important to configure the basics by editing the `.env` file. Work through the file and read the comments before updating each setting.
 
 <div class="note info">
   <h5>Getting stuck?</h5>
@@ -33,16 +38,16 @@ Before starting the containers it's important to configure the basics by editing
 ## Ready to go
 We are now ready to start the stack. You can bring the lancache.net stack up typing
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 If you wish to stop it later simply type
 ```sh
-docker-compose down
+docker compose down
 ```
 
 
 ## Configuring your firewall
-Once lancache-dns and monolithic are up and running you need to configure your router to hand out the IP address of the lancache-dns instance instead of your usual default. This is called "DNS poisoning" and is the primary intercept method for our cachable traffic. 
+Once lancache-dns and monolithic are up and running you need to configure your router to hand out the IP address of the lancache-dns instance instead of your usual default. This is called "DNS poisoning" and is the primary intercept method for our cachable traffic.
 
 The ideal solution when deploying lancache.net is to distribute the IP of your lancache-dns server via dhcp. Many commercial routers will have an option under __LAN settings__ (or similar) to change the _DNS Server IP_. Unfortunately not all consumer brand routers are so versatile so if you cannot find a LAN DNS setting you can use the WAN settings instead. There are many different makes and models of router and each is configured differently. We have put together a guide for some common makes and models which can be found [here](/docs/installation/routers/)
 
@@ -67,12 +72,12 @@ nslookup lancache.steamcontent.com
 2. Download a game through steam
 * If everything is working you should find the first time you download a game speeds which are equivalent to your internet speed. You  may find that initial downloads through the cache are slightly slower, but thats ok.
 
-    <div class="note info">      
-    <h5>Why do we cache</h5>   
+    <div class="note info">
+    <h5>Why do we cache</h5>
     <p>
     We cache traffic in order to provide benefit to many users in a large environment. LanCache is optimised for hundreds to thousands of gamers downloading at once not one or two users on a small scale. The emphasis is always on superior cached performance over uncached.
     </p>
-    </div>                          
+    </div>
 
 
 3. Uninstall the first game and download again

--- a/_docs/installation/docker.md
+++ b/_docs/installation/docker.md
@@ -4,7 +4,7 @@ description: Official guide to install lancache.net
 permalink: /docs/installation/docker/
 ---
 
-The best and quickest way is to get started with lancache.net is to use the [quickstart](/docs/home/). The below guides give more information on how to implement these containers without using docker-compose if you have a specific reason not to do so.
+The best and quickest way is to get started with lancache.net is to use the [quickstart](/docs/home/). The below guides give more information on how to implement these containers without using docker compose if you have a specific reason not to do so.
 
 ## Requirements
 

--- a/_docs/upgrading.md
+++ b/_docs/upgrading.md
@@ -13,7 +13,7 @@ permalink: /docs/upgrading/
 
 ## Minor Updates
 
-If you followed our setup recommendations and installed via [docker-compose](/docs/installation/docker-compose), run `docker-compose pull` to update the containers and then `docker-compose up -d` to update to the latest versions.
+If you followed our setup recommendations and installed via [docker compose](/docs/installation/docker-compose), run `docker compose pull` to update the containers and then `docker compose up -d` to update to the latest versions.
 
 If you are using docker directly you will need to destroy and recreate your containers after repulling the latest image {% comment %}(See [docker-101](/docs/docker-101)) {% endcomment %}.
 

--- a/_docs/useful-commands.md
+++ b/_docs/useful-commands.md
@@ -5,7 +5,7 @@ permalink: "/docs/useful-commands/"
 This page will show you some useful commands when troubleshooting issues with your lancache setup. If this doesn't work out you can always [check out the support page](https://lancache.net/support/).
 
 # Client device commands
-These commands can be run from the client device you are trying to access the lancache from. 
+These commands can be run from the client device you are trying to access the lancache from.
 
 
 |Command		|  Explanation											|
@@ -23,7 +23,7 @@ These commands can be run from the client device you are trying to access the la
 <br><br>
 
 # Lancache server commands
-These commands can be run from the lancache server. For the docker commands it is recommended to use a privileged user. 
+These commands can be run from the lancache server. For the docker commands it is recommended to use a privileged user.
 For more information on using docker with a privileged user see [this documentation](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
 Adding `sudo` in front of the command also works.
 
@@ -32,9 +32,9 @@ Adding `sudo` in front of the command also works.
 |`docker logs <container_id>`                        |  This command shows the logs of a specific docker container. `<container_name>` could be used instead of `<container_id>`. The container names *(normally)* are `lancache_monolithic_1` and `lancache_dns_1`   |
 |`docker container ls -a`  | This command shows all docker containers *(including stopped ones)*|
 |`docker status` | This command shows the active status of docker |
-|`docker-compose up -d` | This command will create the docker container(s) for the LanCache and start running it |
-|`docker-compose down` | This command will stop all the running docker containers |
-|`docker-compose down && docker-compose up -d` | This command stops all running docker containers and restarts them afterwards |
+|`docker compose up -d` | This command will create the docker container(s) for the LanCache and start running it |
+|`docker compose down` | This command will stop all the running docker containers |
+|`docker compose restart` | This command stops all running docker containers and restarts them afterwards |
 | `lsof -i tcp:<port>`| This command shows the services running on a specific port  |
 | `ip -a` | This command shows all the ip information for your caching server|
 | `find /your/cache/folder -type f -exec awk 'FNR>2 {nextfile} ``/origin\/eamaster\/s\/shift\``/mass_effect\/mass_effect_andromeda\/patchww_ww\``/mass_effect_andromedapcpatchww_wwconcept_670739583_``pc_retail_patch_fe0ac79761d8c4feba5831a96cfbc7fc6.zip/ ``{ print FILENAME ; nextfile }' '{}' +` | This command allows you to remove a corrupt file from the LanCache. **This process takes a very long time on large caches (multiple hours), be patient** |

--- a/_docs/useful-commands.md
+++ b/_docs/useful-commands.md
@@ -34,7 +34,7 @@ Adding `sudo` in front of the command also works.
 |`docker status` | This command shows the active status of docker |
 |`docker compose up -d` | This command will create the docker container(s) for the LanCache and start running it |
 |`docker compose down` | This command will stop all the running docker containers |
-|`docker compose restart` | This command stops all running docker containers and restarts them afterwards |
+|`docker compose down && docker compose up -d` | This command stops all running docker containers and restarts them afterwards |
 | `lsof -i tcp:<port>`| This command shows the services running on a specific port  |
 | `ip -a` | This command shows all the ip information for your caching server|
 | `find /your/cache/folder -type f -exec awk 'FNR>2 {nextfile} ``/origin\/eamaster\/s\/shift\``/mass_effect\/mass_effect_andromeda\/patchww_ww\``/mass_effect_andromedapcpatchww_wwconcept_670739583_``pc_retail_patch_fe0ac79761d8c4feba5831a96cfbc7fc6.zip/ ``{ print FILENAME ; nextfile }' '{}' +` | This command allows you to remove a corrupt file from the LanCache. **This process takes a very long time on large caches (multiple hours), be patient** |


### PR DESCRIPTION
Replacing all references to the deprecated **docker-compose** command with **docker compose** instead.